### PR TITLE
Fix logging via target-rtt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,13 +126,14 @@ dependencies = [
 
 [[package]]
 name = "embedded-test"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "defmt",
  "embassy-executor",
  "embedded-test-macros",
  "heapless 0.8.0",
  "log",
+ "rtt-target",
  "semihosting",
  "serde",
  "serde-json-core",
@@ -256,6 +257,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rtt-target"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b34c9e6832388e45f3c01f1bb60a016384a0a4ad80cdd7d34913bed25037f0"
+dependencies = [
+ "critical-section",
+ "ufmt-write",
 ]
 
 [[package]]
@@ -383,6 +394,12 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
+
+[[package]]
+name = "ufmt-write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["embedded", "no-std", "development-tools::testing"]
 
 # Dependencies when this crate is used as library
 [dependencies]
+rtt-target = { version = "0.5.0", optional = true }
 semihosting = { version ="0.1.5", features = ["args"] }
 embedded-test-macros = {version="0.3.0",path = "./macros" }
 defmt = { version = "0.3.5", optional = true }
@@ -23,6 +24,7 @@ embassy-executor = { version = "0.4.0", optional=true, default-features = false 
 
 [features]
 defmt = ["dep:defmt"]
+rtt = ["dep:rtt-target"]
 log = ["dep:log"]
 
 embassy = ["embedded-test-macros/embassy", "dep:embassy-executor"] # Note: You need to enable at least one executor feature on embassy

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -349,6 +349,7 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
 
         #[export_name = "main"]
         unsafe extern "C" fn __defmt_test_entry() -> ! {
+            #krate::export::init_logging();
             const TEST_COUNT : usize = #test_count;
             const TEST_NAMES_STRLEN : usize = #test_names_strlen;
             let mut test_funcs: #krate::export::Vec<#krate::export::Test, TEST_COUNT> = #krate::export::Vec::new();

--- a/src/export.rs
+++ b/src/export.rs
@@ -98,3 +98,8 @@ pub fn check_outcome<T: TestOutcome>(outcome: T) -> ! {
         semihosting::process::abort();
     }
 }
+
+pub fn init_logging() {
+    #[cfg(feature = "rtt")]
+    rtt_target::rtt_init_print!();
+}


### PR DESCRIPTION
If `target-rtt` is used instead of `defmt` and `rtt_target::rtt_init_print!()` is called at the beggining of the `#[init]` function, it still does not print anything and fails to attach to RTT, at least on Cortex-M3 (STM32F103RE to be exact). Enabling the `rtt` feature (this PR) and removing `rtt_target::rtt_init_print!()` from `#[init]` seems to fix it.