### PR TITLE
Configurable executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 ### Added
+- Make it possible to bring your own Embassy executor
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
 name = "embedded-test-macros"
 version = "0.4.0"
 dependencies = [
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.53",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ init-rtt = ["dep:rtt-target"]
 init-log = ["dep:rtt-log"]
 
 # you will use your own executor by setting it via the `tasks` macro, e.g. `#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]`
-external-executor = []
+external-executor = ["embedded-test-macros/external-executor"]
 
 # Note: You need to enable at least one executor feature on embassy unless you are using the `external-executor` feature
 embassy = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,28 @@ embassy-executor = { version = "0.5.0", optional = true, default-features = fals
 [features]
 default = ["panic-handler"]
 
-panic-handler = [] # defines a panic-handler which will invoke `semihosting::process::abort()` on panic
+# defines a panic-handler which will invoke `semihosting::process::abort()` on panic
+panic-handler = []
 
-defmt = ["dep:defmt"] # prints testcase exit result to defmt
-log = ["dep:log"] # prints testcase exit result to log
+# prints testcase exit result to defmt
+defmt = ["dep:defmt"]
 
-init-rtt = ["dep:rtt-target"] # calls `rtt_target::rtt_init_print!()` before starting any tests
-init-log = ["dep:rtt-log"] # calls `rtt_log::init();` before starting any tests
+# prints testcase exit result to log
+log = ["dep:log"]
 
-embassy = ["embedded-test-macros/embassy", "dep:embassy-executor"] # Note: You need to enable at least one executor feature on embassy
+# calls `rtt_target::rtt_init_print!()` before starting any tests
+init-rtt = ["dep:rtt-target"]
+
+# calls `rtt_log::init();` before starting any tests
+init-log = ["dep:rtt-log"]
+
+# you will use your own executor by setting it via the `tasks` macro, e.g. `#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]`
+external-executor = []
+
+# Note: You need to enable at least one executor feature on embassy unless you are using the `external-executor` feature
+embassy = [
+    "embedded-test-macros/embassy",
+    "dep:embassy-executor",
+]
 
 xtensa-semihosting = ["semihosting/openocd-semihosting"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 proc-macro2 = "1.0.79"
 quote = "1.0.35"
 syn = { version = "2.0.52", features = ["extra-traits", "full"] }
+darling = "0.20.8"
 
 [features]
 embassy = []

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -20,6 +20,7 @@ darling = "0.20.8"
 
 [features]
 embassy = []
+external-executor = []
 
 [dev-dependencies]
 trybuild = "1"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -34,6 +34,14 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
         }
     };
 
+    #[cfg(not(all(feature = "embassy", feature = "external-executor")))]
+    if macro_args.executor.is_some() {
+        return Err(parse::Error::new(
+            proc_macro2::Span::call_site(),
+            "`#[test]` attribute doesn't take an executor unless the features `embassy` and `external-executor` are enabled",
+        ));
+    }
+
     let module: ItemMod = syn::parse(input)?;
 
     let items = if let Some(content) = module.content {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -38,7 +38,7 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
     if macro_args.executor.is_some() {
         return Err(parse::Error::new(
             proc_macro2::Span::call_site(),
-            "`#[test]` attribute doesn't take an executor unless the features `embassy` and `external-executor` are enabled",
+            "`#[embedded_test::tests]` attribute doesn't take an executor unless the features `embassy` and `external-executor` are enabled",
         ));
     }
 


### PR DESCRIPTION
This allows to use a custom Embassy executor.

e.g.
`#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]`

We need it to run tests on Xtensa targets.
There is code using this here: https://github.com/bjoernQ/esp-hal/tree/experiment-async-tests-on-xtensa2/hil-test

This shouldn't cause any behavior changes otherwise

There are a few unrelated changes due to reformatting the files I changed
