### PR TITLE
Update rtt-log to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,11 +295,12 @@ dependencies = [
 
 [[package]]
 name = "rtt-log"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934c5a2ab52e91070e60e400ed9c9f2f28d9469b06b974e5d463e98bc7c0e185"
+checksum = "f7ae9de69f95134a36de2a40848955b56dc93ec337d9a08207c55f381c251ecb"
 dependencies = [
  "log",
+ "once_cell",
  "rtt-target",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ heapless = "0.8.0"
 
 # Optional dependencies
 rtt-target = { version = "0.5.0", optional = true }
-rtt-log = { version = "0.3.0", optional = true }
+rtt-log = { version = "0.4.0", optional = true }
 defmt = { version = "0.3.8", optional = true }
 log = { version = "0.4.20", optional = true }
 embassy-executor = { version = "0.6.1", optional = true, default-features = false }


### PR DESCRIPTION
Using the `init-log` feature on targets that do not support atomics (e.g. riscv32imc-unknown-none-elf) causes builds to fail, because the currently used version of rtt-log (v0.3.0) assumes that there always exist functions `log::set_logger()` and `log::set_max_level()`. However, this is is not the case for these architectures. Here, `log::set_logger_racy()` and `log::set_max_level_racy()` have to be called instead.  This problem has been fixed in rtt-log v0.4.0. Therefore, this commit bumps the dependency to that version, allowing `init-log` to be used on targets without native atomics support.

Fixes #45