### PR TITLE
feat: add Ariel OS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Support [Ariel OS](https://ariel-os.org).
+
 ## [0.6.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,5 +46,8 @@ embassy = [
 # you will use your own executor by setting it via the `tasks` macro, e.g. `#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]`
 external-executor = ["embedded-test-macros/external-executor"]
 
+# Enables Ariel OS integration
+ariel-os = ["embedded-test-macros/ariel-os", "embassy"]
+
 # enables the xtensa-specific semihosting implementation
 xtensa-semihosting = ["semihosting/openocd-semihosting"]

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ mod tests {
 | `embassy`            | No       | Enables async test and init functions. Note: You need to enable at least one executor feature on the embassy-executor crate unless you are using the `external-executor` feature.             |
 | `external-executor`  | No       | Allows you to bring your own embassy executor which you need to pass to the `#[tests]` macro (e.g. `#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]`) |
 | `xtensa-semihosting` | No       | Enables semihosting for xtensa targets.                                                                                                                                                       |
+| `ariel-os`           | No       | Enables [Ariel OS](https://ariel-os.github.io/ariel-os/dev/docs/book/testing.html) integration.                                                                                               |
 
 Please also note the doc for
 the [Attribute Macro embedded_test::tests](https://docs.rs/embedded-test/latest/embedded-test/attr.tests.html).

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@ macro_rules! assert_unique_features {
 
 fn main() -> Result<(), Box<dyn Error>> {
     assert_unique_features!("log", "defmt");
+    assert_unique_features!("ariel-os", "external-executor");
 
     let out = &PathBuf::from(env::var("OUT_DIR")?);
     let linker_script = fs::read_to_string("embedded-test.x")?;

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,6 +21,7 @@ darling = "0.20.8"
 [features]
 embassy = []
 external-executor = []
+ariel-os = []
 
 [dev-dependencies]
 trybuild = "1"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -93,6 +93,14 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
         ));
     }
 
+    #[cfg(feature = "ariel-os")]
+    if macro_args.executor.is_some() {
+        return Err(parse::Error::new(
+            proc_macro2::Span::call_site(),
+            "`#[embedded_test::tests]` attribute doesn't take an executor the feature `ariel-os` is enabled",
+        ));
+    }
+
     let module: ItemMod = syn::parse(input)?;
 
     let items = if let Some(content) = module.content {
@@ -339,6 +347,12 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
             }
         );
 
+        let task_path = if cfg!(feature = "ariel-os") {
+            quote!(ariel_os::task)
+        } else {
+            quote!(#krate::export::task)
+        };
+
         // The closure that will be called, if the test should be runned.
         // This closure has the signature () -> !, so it will never return.
         // The closure will signal the test result via semihosting exit/abort instead
@@ -347,29 +361,37 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
             let cfgs = &test.cfgs;
             test_function_invokers.push(quote!(
                   #(#cfgs)*
-                  #[#krate::export::task]
+                  #[#task_path]
                   async fn #ident_invoker() {
                       #init_run_and_check
                   }
             ));
 
-            let executor = if let Some(executor) = &macro_args.executor {
-                quote! {
-                    #executor
-                }
-            } else {
-                quote! {
-                    #krate::export::Executor::new()
-                }
-            };
-
-            quote!(|| {
-                let mut executor = #executor;
-                let executor = unsafe { __make_static(&mut executor) };
-                executor.run(|spawner| {
-                    spawner.must_spawn(#ident_invoker());
+            if cfg!(feature = "ariel-os") {
+                quote!(|| {
+                    ariel_os::asynch::spawner().must_spawn(#ident_invoker());
+                    ariel_os::thread::park();
+                    unreachable!();
                 })
-            })
+            } else {
+                let executor = if let Some(executor) = &macro_args.executor {
+                    quote! {
+                        #executor
+                    }
+                } else {
+                    quote! {
+                        #krate::export::Executor::new()
+                    }
+                };
+
+                quote!(|| {
+                    let mut executor = #executor;
+                    let executor = unsafe { __make_static(&mut executor) };
+                    executor.run(|spawner| {
+                        spawner.must_spawn(#ident_invoker());
+                    })
+                })
+            }
         } else {
             quote!(|| {
                 #init_run_and_check
@@ -420,6 +442,22 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
     };
     let setup = macro_args.setup;
 
+    let (thread_start, maybe_export_name) = if cfg!(feature = "ariel-os") {
+        (
+            quote!(
+                // TODO: make stack size configurable
+                //#[cfg(feature = "ariel-os")]
+                #[ariel_os::thread(autostart, stacksize = 16384)]
+                fn embedded_test_thread() {
+                    unsafe { __embedded_test_entry() }
+                }
+            ),
+            quote!(),
+        )
+    } else {
+        (quote!(), quote!(#[export_name = "main"]))
+    };
+
     Ok(quote!(
     #[cfg(test)]
     mod #ident {
@@ -435,7 +473,9 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
             ::core::mem::transmute(t)
         }
 
-        #[export_name = "main"]
+        #thread_start
+
+        #maybe_export_name
         unsafe extern "C" fn __embedded_test_entry() -> ! {
             // The linker file will redirect this call to the function below.
             // This trick ensures that we get a compile error, if the linker file was not added to the rustflags.

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -446,7 +446,6 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
         (
             quote!(
                 // TODO: make stack size configurable
-                //#[cfg(feature = "ariel-os")]
                 #[ariel_os::thread(autostart, stacksize = 16384)]
                 fn embedded_test_thread() {
                     unsafe { __embedded_test_entry() }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -93,14 +93,6 @@ fn tests_impl(args: TokenStream, input: TokenStream) -> parse::Result<TokenStrea
         ));
     }
 
-    #[cfg(feature = "ariel-os")]
-    if macro_args.executor.is_some() {
-        return Err(parse::Error::new(
-            proc_macro2::Span::call_site(),
-            "`#[embedded_test::tests]` attribute doesn't take an executor the feature `ariel-os` is enabled",
-        ));
-    }
-
     let module: ItemMod = syn::parse(input)?;
 
     let items = if let Some(content) = module.content {

--- a/src/export.rs
+++ b/src/export.rs
@@ -15,9 +15,13 @@ pub fn ensure_linker_file_was_added_to_rustflags() -> ! {
 }
 
 // Reexport the embassy stuff
-#[cfg(feature = "embassy")]
+#[cfg(all(feature = "embassy", not(feature = "ariel-os")))]
 pub use embassy_executor::task;
-#[cfg(all(feature = "embassy", not(feature = "external-executor")))]
+#[cfg(all(
+    feature = "embassy",
+    not(feature = "external-executor"),
+    not(feature = "ariel-os")
+))]
 pub use embassy_executor::Executor; // Please activate the `executor-thread` or `executor-interrupt` feature on the embassy-executor crate (v0.7.x)!
 
 const VERSION: u32 = 1; //Format version of our protocol between probe-rs and target running embedded-test

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod fmt;
 
 pub use embedded_test_macros::tests;
 
-#[cfg(feature = "panic-handler")]
+#[cfg(all(feature = "panic-handler", not(feature = "ariel-os")))]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     error!("====================== PANIC ======================");


### PR DESCRIPTION
This PR adds [Ariel OS](https://ariel-os.org) integration to embedded-test.

Ariel is a bit different from regular bare-metal targets:

1. It takes care of a lot of system setup (logging, network, panic handler...)
2. It provides threads alongside async tasks

This is reflected in the integration, e.g., non-async tests are run in a thread.

We have an [example](https://github.com/ariel-os/ariel-os/tree/main/examples/testing) on how to use this, and a [book chapter](https://ariel-os.github.io/ariel-os/dev/docs/book/testing.html) with more info.

I've tried to find generic solutions here instead of a blanket "ariel-os" feature, but it became messy. So this is what we're using now.