### PR TITLE
Remove the test cfg gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- Removed the `#[cfg(test)]` attribute from the test module.
+
 ## [0.7.0-alpha.3]
 
 ### Changed

--- a/macros/src/attributes/tests.rs
+++ b/macros/src/attributes/tests.rs
@@ -25,7 +25,6 @@ pub(crate) fn expand(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let mod_name = format_ident!("{}", validated_module.module_name);
     quote!(
-        #[cfg(test)]
         mod #mod_name {
             #(#untouched_tokens)*
 


### PR DESCRIPTION
For one, the readme showcases code that adds `#[cfg(test)]` above `#[embedded_test::tests]` so users (us :D ) already think it's necessary.

The other reason for this PR is a bit more nuanced.

`cargo build --test xy --artifact-dir place-the-test-here` doesn't work. This prevents us from using cargo-batch to build tests in one go (or, well, fewer than 50 gos). However, the cfg prevents us from turning the test binaries into "real" binaries, where everything just works.