### PR TITLE
feat(deps): support both embassy-executor 0.9.x and 0.10.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support embassy-executor v0.10.x via feature `embassy010`
+
 ## [0.7.0]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,45 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cordyceps"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
+dependencies = [
+ "loom",
+ "tracing",
+]
 
 [[package]]
 name = "critical-section"
@@ -133,7 +168,20 @@ checksum = "d0c80c92a31c7f6b02a938f10feea17ea3cc0e8d33bcac7f3fe8cede3723bb56"
 dependencies = [
  "critical-section",
  "document-features",
- "embassy-executor-macros",
+ "embassy-executor-macros 0.7.0",
+ "embassy-executor-timer-queue",
+]
+
+[[package]]
+name = "embassy-executor"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0d3b15c9d7dc4fec1d8cb77112472fb008b3b28c51ad23838d83587a6d2f1e"
+dependencies = [
+ "cordyceps",
+ "critical-section",
+ "document-features",
+ "embassy-executor-macros 0.8.0",
  "embassy-executor-timer-queue",
 ]
 
@@ -142,6 +190,18 @@ name = "embassy-executor-macros"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfdddc3a04226828316bf31393b6903ee162238576b1584ee2669af215d55472"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "embassy-executor-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11a246f53de5f97a387f40ac24726817cd0b6f833e7603baac784f29d6ff276"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -160,7 +220,8 @@ name = "embedded-test"
 version = "0.7.0"
 dependencies = [
  "defmt",
- "embassy-executor",
+ "embassy-executor 0.10.0",
+ "embassy-executor 0.9.0",
  "embedded-test-linker-script",
  "embedded-test-macros",
  "linkme",
@@ -186,10 +247,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
 
 [[package]]
 name = "ident_case"
@@ -202,6 +284,18 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "linkme"
@@ -236,10 +330,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -282,10 +419,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "semihosting"
@@ -326,6 +492,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,7 +550,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ linkme = { version = "0.3.31", optional = true }
 # Optional dependencies
 defmt = { version = "1", optional = true }
 log = { version = "0.4.20", optional = true }
-embassy-executor = { version = "0.9", optional = true, default-features = false }
-
+embassy-executor-09 = { package = "embassy-executor", version = "0.9", optional = true, default-features = false }
+embassy-executor-010 = { package = "embassy-executor", version = "0.10", optional = true, default-features = false }
 
 [features]
 default = ["semihosting", "panic-handler"]
@@ -45,13 +45,19 @@ log = ["dep:log"]
 
 # Enables async test and init functions using embassy-executor.
 # Note: You need to enable at least one executor feature on embassy unless you are using the `external-executor` feature
-embassy = ["embedded-test-macros/embassy", "dep:embassy-executor"]
+embassy = ["embassy09"]
+embassy09 = ["embassy-any", "embedded-test-macros/embassy09", "dep:embassy-executor-09"]
+embassy010 = ["embassy-any", "embedded-test-macros/embassy010", "dep:embassy-executor-010"]
+
+embassy-any = []
 
 # you will use your own executor by setting it via the `tasks` macro, e.g. `#[embedded_test::tests(executor = esp_hal::embassy::executor::thread::Executor::new())]`
 external-executor = ["embedded-test-macros/external-executor"]
 
 # Enables Ariel OS integration
-ariel-os = ["embedded-test-macros/ariel-os", "embassy"]
+ariel-os = ["embedded-test-macros/ariel-os", "embedded-test-macros/embassy09", "embassy", "ariel-os-any"]
+ariel-os-010 = ["embedded-test-macros/ariel-os", "embedded-test-macros/embassy010", "embassy010", "ariel-os-any"]
+ariel-os-any = []
 
 # enables the xtensa-specific semihosting implementation
 xtensa-semihosting = ["semihosting/openocd-semihosting"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,7 +21,8 @@ darling = "0.21.1"
 
 [features]
 embassy = []
-external-executor = []
+embassy09 = ["embassy"]
+embassy010 = ["embassy"]
+external-executor = ["embassy"]
 ariel-os = []
 std = []
-

--- a/macros/src/attributes/tests/codegen/wrap_with_executor.rs
+++ b/macros/src/attributes/tests/codegen/wrap_with_executor.rs
@@ -39,9 +39,17 @@ pub(crate) fn wrap_with_executor(
           }
     );
 
+    let spawn_invoker = if cfg!(feature = "embassy09") {
+        quote!( spawn(#ident_invoker()).unwrap() )
+    } else if cfg!(feature = "embassy010") {
+        quote!( spawn(#ident_invoker().unwrap()) )
+    } else {
+        panic!("must select embassy09 or embassy10 feature");
+    };
+
     let spawner_block = if cfg!(feature = "ariel-os") {
         quote!( {
-            ariel_os::asynch::spawner().must_spawn(#ident_invoker());
+            ariel_os::asynch::spawner().#spawn_invoker;
             ariel_os::thread::park();
             unreachable!();
         })
@@ -53,7 +61,7 @@ pub(crate) fn wrap_with_executor(
             }
             let executor = unsafe { __make_static(&mut executor) };
             executor.run(|spawner| {
-                spawner.must_spawn(#ident_invoker());
+                spawner.#spawn_invoker;
             })
         })
     };

--- a/src/export.rs
+++ b/src/export.rs
@@ -4,13 +4,18 @@ use crate::{export, TestOutcome};
 #[cfg_attr(feature = "semihosting", path = "semihosting.rs")]
 pub mod hosting;
 
+#[cfg(all(feature = "embassy010", not(feature = "ariel-os-any")))]
+use embassy_executor_010 as embassy_executor;
+#[cfg(all(feature = "embassy09", not(feature = "ariel-os-any")))]
+use embassy_executor_09 as embassy_executor;
+
 // Reexport the embassy stuff
-#[cfg(all(feature = "embassy", not(feature = "ariel-os")))]
+#[cfg(all(feature = "embassy-any", not(feature = "ariel-os-any")))]
 pub use embassy_executor::task;
 #[cfg(all(
-    feature = "embassy",
+    feature = "embassy-any",
     not(feature = "external-executor"),
-    not(feature = "ariel-os")
+    not(feature = "ariel-os-any")
 ))]
 pub use embassy_executor::Executor; // Please activate the `executor-thread` or `executor-interrupt` feature on the embassy-executor crate (v0.9.x)!
 
@@ -26,7 +31,7 @@ pub fn check_outcome<T: TestOutcome>(outcome: T) -> ! {
 
 // Ariel OS invokes the `__embedded_test_entry` function directly
 // Otherwise we export it as `main` function.
-#[cfg_attr(not(feature = "ariel-os"), export_name = "main")]
+#[cfg_attr(not(feature = "ariel-os-any"), export_name = "main")]
 pub unsafe extern "C" fn __embedded_test_entry() -> ! {
     ensure_linker_file_was_added_to_rustflags();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod fmt;
 
 pub use embedded_test_macros::{setup, tests};
 
-#[cfg(all(feature = "panic-handler", not(feature = "ariel-os")))]
+#[cfg(all(feature = "panic-handler", not(feature = "ariel-os-any")))]
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
     error!("====================== PANIC ======================");


### PR DESCRIPTION
This adds Cargo features for switching between `embassy-executor 0.9.x` and `0.10.x`, as discussed in #71.

I tried to make this backwards compatible (the `embassy` feature selects `embassy09`).

(Includes https://github.com/probe-rs/embedded-test/pull/79)