### PR TITLE
Do not require the linker script on std

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- The `std` feature no longer needs the `embedded-test.x` linker script, which makes it usable with linkers other
+  than GNU ld (e.g. MSVC) and on macOS. Adding the linker script anyway keeps working.
+
 ## [0.7.2]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ version = "0.1.0"
 
 [[package]]
 name = "embedded-test-macros"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "darling 0.24.0",
  "proc-macro-error3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["embedded", "no-std", "development-tools::testing"]
 default-target = "riscv32imac-unknown-none-elf"
 
 [dependencies]
-embedded-test-macros = { version = "0.8.1", path = "./macros" }
+embedded-test-macros = { version = "0.9.0", path = "./macros" }
 embedded-test-linker-script = { version = "0.1.0", path = "linker-script" }
 semihosting = { version = "0.1.7", features = ["args"], optional = true }
 serde = { version = "1.0.193", default-features = false, features = ["derive"], optional = true }

--- a/examples/esp32c6/Cargo.lock
+++ b/examples/esp32c6/Cargo.lock
@@ -504,7 +504,7 @@ version = "0.1.0"
 
 [[package]]
 name = "embedded-test-macros"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "darling 0.24.0",
  "proc-macro-error3",

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -237,7 +237,6 @@ version = "0.1.0"
 dependencies = [
  "embassy-executor",
  "embedded-test",
- "embedded-test-linker-script",
  "env_logger",
  "log",
 ]
@@ -248,7 +247,7 @@ version = "0.1.0"
 
 [[package]]
 name = "embedded-test-macros"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "darling 0.24.0",
  "proc-macro-error3",

--- a/examples/std/Cargo.toml
+++ b/examples/std/Cargo.toml
@@ -15,8 +15,6 @@ embassy-executor = { default-features = false, version = "0.9", features = ["arc
 log = { version = "0.4.20", optional = true }
 env_logger = { version = "0.11.6", optional = true }
 
-embedded-test-linker-script = { version = "0.1.0", path = "../../linker-script" }
-
 [dev-dependencies]
 embedded-test = { version = "0.7.0", default-features = false, features = ["embassy", "std"], path = "../.." }
 

--- a/examples/std/build.rs
+++ b/examples/std/build.rs
@@ -1,8 +1,7 @@
 use std::env;
 
 fn main() {
-    // add linker script for embedded-test!!
-    println!("cargo::rustc-link-arg=-Tembedded-test.x");
+    // Note: no linker script is needed on std.
     println!("cargo::rustc-check-cfg=cfg(rust_analyzer)");
 
     // Check if the `defmt` feature is enabled, and if so link its linker script

--- a/examples/stm32f767/Cargo.lock
+++ b/examples/stm32f767/Cargo.lock
@@ -335,7 +335,7 @@ version = "0.1.0"
 
 [[package]]
 name = "embedded-test-macros"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "darling 0.24.0",
  "proc-macro-error3",

--- a/macros/Cargo.lock
+++ b/macros/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-test-macros"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "darling",
  "proc-macro-error3",

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "embedded-test-macros"
 description = "proc-macros for the embedded-test crate"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 repository = "https://github.com/probe-rs/embedded-test"
 license = "MIT OR Apache-2.0"

--- a/macros/src/attributes/setup.rs
+++ b/macros/src/attributes/setup.rs
@@ -1,7 +1,7 @@
 // File copied and adapted from https://github.com/knurling-rs/defmt/blob/main/macros/src/attributes/panic_handler.rs
 use proc_macro::TokenStream;
 use proc_macro_error3::{abort, abort_call_site};
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{parse_macro_input, Attribute, ItemFn, ReturnType, Safety};
 
 pub(crate) fn expand(args: TokenStream, item: TokenStream) -> TokenStream {
@@ -62,13 +62,30 @@ fn codegen(fun: &ItemFn) -> TokenStream {
     let block = &fun.block;
     let ident = &fun.sig.ident;
 
-    quote!(
-        #(#attrs)*
-        #[export_name = "_embedded_test_setup"]
-        #[inline(never)]
-        fn #ident() {
-            #block
-        }
-    )
+    if cfg!(feature = "std") {
+        // Export the setup function so that we can collect it using linkme when on std
+        let ident_var = format_ident!("__{}_SETUP_SYM", ident.to_string().to_uppercase());
+        quote!(
+            #(#attrs)*
+            #[inline(never)]
+            fn #ident() {
+                #block
+            }
+
+            #(#attrs)*
+            #[embedded_test::export::hosting::distributed_slice(embedded_test::export::hosting::SETUP)]
+            #[linkme(crate = embedded_test::export::hosting::linkme)]
+            static #ident_var: fn() = #ident;
+        )
+    } else {
+        quote!(
+            #(#attrs)*
+            #[export_name = "_embedded_test_setup"]
+            #[inline(never)]
+            fn #ident() {
+                #block
+            }
+        )
+    }
     .into()
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -33,9 +33,17 @@ pub fn check_outcome<T: TestOutcome>(outcome: T) -> ! {
 // Otherwise we export it as `main` function.
 #[cfg_attr(not(feature = "_ariel"), export_name = "main")]
 pub unsafe extern "C" fn __embedded_test_entry() -> ! {
-    ensure_linker_file_was_added_to_rustflags();
+    // On std there is no linker script, so the start function is reached directly.
+    #[cfg(feature = "std")]
+    unsafe {
+        __embedded_test_start()
+    }
+
+    #[cfg(not(feature = "std"))]
+    ensure_linker_file_was_added_to_rustflags()
 }
 
+#[cfg(not(feature = "std"))]
 fn ensure_linker_file_was_added_to_rustflags() -> ! {
     // Try to access a symbol which we provide in the embedded-test.x linker script.
     // The linker script will redirect this call to the function below.
@@ -49,10 +57,7 @@ fn ensure_linker_file_was_added_to_rustflags() -> ! {
 #[no_mangle]
 unsafe extern "C" fn __embedded_test_start() -> ! {
     // Invoke the user provided setup function, if it exists or run a default (empty) setup function.
-    extern "Rust" {
-        fn _embedded_test_setup();
-    }
-    unsafe { _embedded_test_setup() }
+    hosting::setup();
 
     let args = &export::hosting::args().expect("Failed to get cmdline via semihosting");
     // this is an iterator already with semihosting, not on std
@@ -89,9 +94,7 @@ unsafe extern "C" fn __embedded_test_start() -> ! {
     }
 }
 
-#[export_name = "__embedded_test_default_setup"]
-fn default_setup() {}
-
+#[cfg(not(feature = "std"))]
 #[used]
 #[no_mangle]
 #[link_section = ".embedded_test.meta"]

--- a/src/semihosting.rs
+++ b/src/semihosting.rs
@@ -5,6 +5,18 @@ pub fn args() -> io::Result<Args<1024>> {
     semihosting::experimental::env::args::<1024>()
 }
 
+pub fn setup() {
+    // The embedded-test.x linker script points this at the user provided setup function, or at the
+    // default below if the user did not provide one.
+    extern "Rust" {
+        fn _embedded_test_setup();
+    }
+    unsafe { _embedded_test_setup() }
+}
+
+#[export_name = "__embedded_test_default_setup"]
+fn default_setup() {}
+
 pub fn abort() -> ! {
     semihosting::process::abort()
 }

--- a/src/std.rs
+++ b/src/std.rs
@@ -34,6 +34,18 @@ fn ser_test_name<S: serde::Serializer>(name: &'static str, s: S) -> Result<S::Ok
 #[distributed_slice]
 pub static TESTS: [Test];
 
+// Collected the same way as the tests, because there is no linker script to provide a default.
+#[distributed_slice]
+pub static SETUP: [fn()];
+
+pub fn setup() {
+    match &SETUP[..] {
+        [] => {}
+        [setup] => setup(),
+        _ => panic!("Multiple `#[embedded_test::setup]` functions in one test binary"),
+    }
+}
+
 type Args = Vec<Result<&'static str, Infallible>>;
 
 pub fn args() -> Result<Args, Infallible> {


### PR DESCRIPTION
The script serves no purpose on std but still had to be passed to the linker, excluding linkers without linker script support. probe-rs does not read these binaries, and the setup default now comes from linkme.

Old embedded-test releases must not resolve to the new macros, hence 0.9.0.